### PR TITLE
Fix broken charts in Safari

### DIFF
--- a/duro/server/formatters.py
+++ b/duro/server/formatters.py
@@ -91,8 +91,8 @@ def skip_none(text: Optional[str]) -> str:
 
 
 def format_job(job) -> Dict:
-    start = arrow.get(job["start"]).format()
-    finish = arrow.get(job["finish"]).format() if job["finish"] else None
+    start = str(arrow.get(job["start"]))
+    finish = str(arrow.get(job["finish"])) if job["finish"] else None
 
     return {"table": job["table"], "start": start, "finish": finish}
 

--- a/duro/server/server.py
+++ b/duro/server/server.py
@@ -73,21 +73,21 @@ def get_tables():
 @app.route("/<from_date>/<to_date>")
 def show_current(from_date: str = None, to_date: str = None):
     if from_date:
-        floor = arrow.get(from_date).format()
+        floor = arrow.get(from_date)
     else:
-        floor = arrow.utcnow().replace(minutes=-30).format()
+        floor = arrow.utcnow().replace(minutes=-30)
     if to_date:
-        ceiling = arrow.get(to_date).format()
+        ceiling = arrow.get(to_date)
     else:
-        ceiling = arrow.utcnow().format()
+        ceiling = arrow.utcnow()
     return render_template("current_jobs.html", floor=floor, ceiling=ceiling)
 
 
 @app.route("/api/jobs")
 def jobs():
     db = get_db()
-    floor = arrow.get(request.args.get("from")).timestamp
-    ceiling = arrow.get(request.args.get("to")).timestamp
+    floor = arrow.get(request.args.get("from").replace(' ', '+')).timestamp
+    ceiling = arrow.get(request.args.get("to").replace(' ', '+')).timestamp
     jobs_dict = [format_job(job) for job in get_jobs(floor, ceiling, db)]
     return jsonify(jobs_dict)
 


### PR DESCRIPTION
Charts in Safari doesn't displayed due to dt format used in Safari implementation